### PR TITLE
update exports for node

### DIFF
--- a/javascript/getCustomAttributes.js
+++ b/javascript/getCustomAttributes.js
@@ -86,4 +86,4 @@ const getCustomAttributes = ({ game, board, turn, you }) => {
   };
 };
 
-export default getCustomAttributes;
+module.exports = getCustomAttributes;


### PR DESCRIPTION
Node doesn't like 'export default' unless it's from a .m.js file, this updates to use the older module.exports syntax to be compatible