### PR TITLE
Fixing syntax errors left over from javascript source copy

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -8,11 +8,11 @@ To use this helper script, add the [New Relic Python agent](https://docs.newreli
 from flask import Flask
 
 # Add the New Relic APM agent.
-import newrelic
+import newrelic.agent
 
 # Add the helper script.
 # Feel free to place this wherever makes sense for your application.
-from getCustomAttributes import getCustomAttributes
+from getCustomAttributes import getCustomAttributes, getCustomAttributesEnd
 
 app = Flask(__name__)
 

--- a/python/getCustomAttributes.py
+++ b/python/getCustomAttributes.py
@@ -50,7 +50,7 @@ def getCustomAttributes(data: dict) -> dict:
 
     return attributes
 
-def getCustomAttributes(data: dict) -> dict:
+def getCustomAttributesEnd(data: dict) -> dict:
     game = data["game"]
     board = data["board"]
     you = data["you"]
@@ -65,9 +65,9 @@ def getCustomAttributes(data: dict) -> dict:
         "snakeHealth": you["health"],
         "snakeLength": you["length"],
 
-        "snakeGameWinnerName": board["snakes"][0].name if len(board["snakes"]) > 0 else Null,
-        "snakeGameWinnerId":  board["snakes"][0].id if len(board["snakes"]) > 0 else Null,
-        "snakeGameIsWin": board["snakes"][0].name == you["name"] if len(board["snakes"]) > 0 else False,
+        "snakeGameWinnerName": board["snakes"][0]["name"] if len(board["snakes"]) > 0 else None,
+        "snakeGameWinnerId":  board["snakes"][0]["id"] if len(board["snakes"]) > 0 else None,
+        "snakeGameIsWin": board["snakes"][0]["name"] == you["name"] if len(board["snakes"]) > 0 else False,
         "snakeGameReplayLink": "https://play.battlesnake.com/g/{id}".format(id=game["id"]),
     }
 


### PR DESCRIPTION
Attempted to use the Python Readme/getCustomAttributes file when setting up the Battlesnake dashboards, but noticed a few errors that look like they are left over from porting this from the javascript version of this (I assume that one was created first!)

These are the changes I made for myself, I believe these are the correct changes to merge into the mainline for others wanting to use this template for Python.